### PR TITLE
[FEATURE] Add SoC timestamp forwarding feature in Windows NDIS design

### DIFF
--- a/drivers/windows/drv_ndis_intermediate/drvintf.c
+++ b/drivers/windows/drv_ndis_intermediate/drvintf.c
@@ -12,7 +12,7 @@ suitable structure before forwarding to a specific kernel stack module.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2017, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 


### PR DESCRIPTION
 - This commit introduces the SoC time forwarding capability to the
   Windows NDIS intermediate design using a shared memory.
 - Create a shared memory between kernel and user to hold SoC time
   stamps.
 - Release the shared memory during exit.